### PR TITLE
fix(watchOS): crash when app sent to background

### DIFF
--- a/Sources/Statsig/Gzip.swift
+++ b/Sources/Statsig/Gzip.swift
@@ -59,7 +59,7 @@ func gzipped(_ input: Data) -> Result<Data, GzipError> {
     // Append trailer: CRC32 (4 bytes) and input size mod 2^32 (4 bytes), both little-endian
     let crc = crc32(input)
     var crcLE = crc.littleEndian
-    var inputSizeLE = UInt32(sourceSize % (1 << 32)).littleEndian
+    var inputSizeLE = UInt32(truncatingIfNeeded: sourceSize).littleEndian
     Swift.withUnsafeBytes(of: &crcLE) { output.append(contentsOf: $0) }
     Swift.withUnsafeBytes(of: &inputSizeLE) { output.append(contentsOf: $0) }
     

--- a/Sources/Statsig/StatsigClient+AppLifecycle.swift
+++ b/Sources/Statsig/StatsigClient+AppLifecycle.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension StatsigClient {
     internal func subscribeToApplicationLifecycle() {
+#if !os(watchOS)
         let center = NotificationCenter.default
         
         center.addObserver(
@@ -21,6 +22,7 @@ extension StatsigClient {
             selector: #selector(appDidBecomeActive),
             name: PlatformCompatibility.didBecomeActiveNotification,
             object: nil)
+#endif
     }
 
     internal func unsubscribeFromApplicationLifecycle() {


### PR DESCRIPTION
This PR fixes a crash when the watchOS app is sent to background. More https://github.com/statsig-io/ios-sdk/issues/26